### PR TITLE
Add overlay until option

### DIFF
--- a/pixray.py
+++ b/pixray.py
@@ -1401,7 +1401,7 @@ def train(args, cur_it):
                 num_anim_frames = len(init_image_rgba_list)
                 init_anim_z(args, init_image_rgba_list[cur_anim_index % num_anim_frames])
 
-        if apply_overlay:
+        if apply_overlay(args, cur_it):
             if cur_anim_index is not None:
                 num_anim_frames = len(overlay_image_rgba_list)
                 overlay_image_rgba = overlay_image_rgba_list[cur_anim_index % num_anim_frames]

--- a/pixray.py
+++ b/pixray.py
@@ -1375,6 +1375,11 @@ def init_anim_z(args, init_rgba):
 
 # torch.autograd.set_detect_anomaly(True)
 
+def apply_overlay(args, cur_it):
+    return args.overlay_image is not None and \
+            (cur_it % args.overlay_every) == args.overlay_offset and \
+            (cur_it < args.overlay_until)
+
 def train(args, cur_it):
     global drawer, opts
     global best_loss, best_iter, best_z, num_loss_drop, max_loss_drops, iter_drop_delay
@@ -1396,10 +1401,7 @@ def train(args, cur_it):
                 num_anim_frames = len(init_image_rgba_list)
                 init_anim_z(args, init_image_rgba_list[cur_anim_index % num_anim_frames])
 
-        # if args.overlay_every and cur_it != 0 and \
-        #     (cur_it % (args.overlay_every + args.overlay_offset)) == 0:
-        if args.overlay_image is not None and \
-            (cur_it % args.overlay_every) == args.overlay_offset:
+        if apply_overlay:
             if cur_anim_index is not None:
                 num_anim_frames = len(overlay_image_rgba_list)
                 overlay_image_rgba = overlay_image_rgba_list[cur_anim_index % num_anim_frames]
@@ -1650,6 +1652,7 @@ def setup_parser(vq_parser):
     vq_parser.add_argument("-dc",   "--display_clear", type=str2bool, help="Clear dispaly when updating", default=False, dest='display_clear')
     vq_parser.add_argument("-ove",  "--overlay_every", type=int, help="Overlay image iterations", default=10, dest='overlay_every')
     vq_parser.add_argument("-ovo",  "--overlay_offset", type=int, help="Overlay image iteration offset", default=0, dest='overlay_offset')
+    vq_parser.add_argument("-ovu",  "--overlay_until", type=int, help="Last iteration to continue applying overlay image", default=sys.maxint, dest='overlay_until')
     vq_parser.add_argument("-ovi",  "--overlay_image", type=str, help="Overlay image (if not init)", default=None, dest='overlay_image')
     vq_parser.add_argument(         "--quality", type=str, help="draft, normal, better, best", default="normal", dest='quality')
     vq_parser.add_argument("-asp",  "--aspect", type=str, help="widescreen, square", default="widescreen", dest='aspect')

--- a/pixray.py
+++ b/pixray.py
@@ -1378,7 +1378,7 @@ def init_anim_z(args, init_rgba):
 def apply_overlay(args, cur_it):
     return args.overlay_image is not None and \
             (cur_it % args.overlay_every) == args.overlay_offset and \
-            (cur_it < args.overlay_until)
+            ((args.overlay_until is None) or (cur_it < args.overlay_until))
 
 def train(args, cur_it):
     global drawer, opts
@@ -1652,7 +1652,7 @@ def setup_parser(vq_parser):
     vq_parser.add_argument("-dc",   "--display_clear", type=str2bool, help="Clear dispaly when updating", default=False, dest='display_clear')
     vq_parser.add_argument("-ove",  "--overlay_every", type=int, help="Overlay image iterations", default=10, dest='overlay_every')
     vq_parser.add_argument("-ovo",  "--overlay_offset", type=int, help="Overlay image iteration offset", default=0, dest='overlay_offset')
-    vq_parser.add_argument("-ovu",  "--overlay_until", type=int, help="Last iteration to continue applying overlay image", default=sys.maxsize, dest='overlay_until')
+    vq_parser.add_argument("-ovu",  "--overlay_until", type=int, help="Last iteration to continue applying overlay image", default=None, dest='overlay_until')
     vq_parser.add_argument("-ovi",  "--overlay_image", type=str, help="Overlay image (if not init)", default=None, dest='overlay_image')
     vq_parser.add_argument(         "--quality", type=str, help="draft, normal, better, best", default="normal", dest='quality')
     vq_parser.add_argument("-asp",  "--aspect", type=str, help="widescreen, square", default="widescreen", dest='aspect')

--- a/pixray.py
+++ b/pixray.py
@@ -1652,7 +1652,7 @@ def setup_parser(vq_parser):
     vq_parser.add_argument("-dc",   "--display_clear", type=str2bool, help="Clear dispaly when updating", default=False, dest='display_clear')
     vq_parser.add_argument("-ove",  "--overlay_every", type=int, help="Overlay image iterations", default=10, dest='overlay_every')
     vq_parser.add_argument("-ovo",  "--overlay_offset", type=int, help="Overlay image iteration offset", default=0, dest='overlay_offset')
-    vq_parser.add_argument("-ovu",  "--overlay_until", type=int, help="Last iteration to continue applying overlay image", default=sys.maxint, dest='overlay_until')
+    vq_parser.add_argument("-ovu",  "--overlay_until", type=int, help="Last iteration to continue applying overlay image", default=sys.maxsize, dest='overlay_until')
     vq_parser.add_argument("-ovi",  "--overlay_image", type=str, help="Overlay image (if not init)", default=None, dest='overlay_image')
     vq_parser.add_argument(         "--quality", type=str, help="draft, normal, better, best", default="normal", dest='quality')
     vq_parser.add_argument("-asp",  "--aspect", type=str, help="widescreen, square", default="widescreen", dest='aspect')

--- a/tests/test_pixray.py
+++ b/tests/test_pixray.py
@@ -7,25 +7,43 @@ class TestPixrayMethods(unittest.TestCase):
         return setup_parser(parser)
     
     def get_args_for_apply_overlay_test(self, overlay_image, overlay_every, overlay_offset, overlay_until):
+        settings = { 
+                     '--overlay_image': overlay_image,
+                     '--overlay_every': overlay_every,
+                     '--overlay_offset': overlay_offset,
+                     '--overlay_until': overlay_until 
+                   }
+
+        return self.parse_dictionary_to_args(settings)
+
+    def parse_dictionary_to_args(self, settings_dict):
         parser = self.setup_test_parser()
-        args = ['--overlay_image', overlay_image, '--overlay_every', str(overlay_every), '--overlay_offset', str(overlay_offset), '--overlay_until', str(overlay_until)]
+        args = []
+        for key, value in settings_dict.items():
+            if value is not None:
+                args.append(key)
+                args.append(value)
+            
         return parser.parse_args(args)
 
     def test_apply_overlay_all_true(self):
-        args = self.get_args_for_apply_overlay_test('image.png', 1, 0, 100)
+        args = self.get_args_for_apply_overlay_test('image.png', '1', '0', '100')
         self.assertEqual(apply_overlay(args, 10), True)
 
     def test_apply_overlay_no_overlay_image(self):
-        args = self.get_args_for_apply_overlay_test(None, 1, 0, 100)
-        args.overlay_image = None
+        args = self.get_args_for_apply_overlay_test(None, '1', '0', '100')
         self.assertEqual(apply_overlay(args, 10), False)
 
     def test_apply_overlay_not_at_offset(self):
-        args = self.get_args_for_apply_overlay_test('image.png', 5, 10, 100)
+        args = self.get_args_for_apply_overlay_test('image.png', '5', '10', '100')
+        self.assertEqual(apply_overlay(args, 10), False)
+
+    def test_apply_overlay_overlay_until_none(self):
+        args = self.get_args_for_apply_overlay_test('image.png', '5', '10', None)
         self.assertEqual(apply_overlay(args, 10), False)
 
     def test_apply_overlay_less_than_overlay_until(self):
-        args = self.get_args_for_apply_overlay_test('image.png', 1, 0, 5)
+        args = self.get_args_for_apply_overlay_test('image.png', '1', '0', '5')
         self.assertEqual(apply_overlay(args, 10), False)
 
 if __name__ == '__main__':

--- a/tests/test_pixray.py
+++ b/tests/test_pixray.py
@@ -2,30 +2,30 @@ import unittest
 from pixray import *
 
 class TestPixrayMethods(unittest.TestCase):
-    def setupTestParser(self):
+    def setup_test_parser(self):
         parser = argparse.ArgumentParser()
         return setup_parser(parser)
     
-    def getArgsForApplyOverlayTest(self, overlay_image, overlay_every, overlay_offset, overlay_until):
-        parser = self.setupTestParser()
+    def get_args_for_apply_overlay_test(self, overlay_image, overlay_every, overlay_offset, overlay_until):
+        parser = self.setup_test_parser()
         args = ['--overlay_image', overlay_image, '--overlay_every', str(overlay_every), '--overlay_offset', str(overlay_offset), '--overlay_until', str(overlay_until)]
         return parser.parse_args(args)
 
     def test_apply_overlay_all_true(self):
-        args = self.getArgsForApplyOverlayTest('image.png', 1, 0, 100)
+        args = self.get_args_for_apply_overlay_test('image.png', 1, 0, 100)
         self.assertEqual(apply_overlay(args, 10), True)
 
     def test_apply_overlay_no_overlay_image(self):
-        args = self.getArgsForApplyOverlayTest(None, 1, 0, 100)
+        args = self.get_args_for_apply_overlay_test(None, 1, 0, 100)
         args.overlay_image = None
         self.assertEqual(apply_overlay(args, 10), False)
 
     def test_apply_overlay_not_at_offset(self):
-        args = self.getArgsForApplyOverlayTest('image.png', 5, 10, 100)
+        args = self.get_args_for_apply_overlay_test('image.png', 5, 10, 100)
         self.assertEqual(apply_overlay(args, 10), False)
 
     def test_apply_overlay_less_than_overlay_until(self):
-        args = self.getArgsForApplyOverlayTest('image.png', 1, 0, 5)
+        args = self.get_args_for_apply_overlay_test('image.png', 1, 0, 5)
         self.assertEqual(apply_overlay(args, 10), False)
 
 if __name__ == '__main__':

--- a/tests/test_pixray.py
+++ b/tests/test_pixray.py
@@ -1,0 +1,15 @@
+import unittest
+from pixray import *
+
+#TODO: Refactor pixray so that arguments can be mocked more cleanly.
+
+class TestPixrayMethods(unittest.TestCase):
+    def setupTestParser(self):
+        parser = argparse.ArgumentParser()
+        return setup_parser(parser)
+    
+    def apply_overlay_all_true(self):
+        parser = self.setupTestParser()
+        args = ['--overlay_image', 'asdf', '--overlay_every', 1, '--overlay_offset', 1, '--overlay_until', 100]
+        result = parser.parse_args(args)
+        self.assertEqual(apply_overlay(args, 10))

--- a/tests/test_pixray.py
+++ b/tests/test_pixray.py
@@ -1,15 +1,32 @@
 import unittest
 from pixray import *
 
-#TODO: Refactor pixray so that arguments can be mocked more cleanly.
-
 class TestPixrayMethods(unittest.TestCase):
     def setupTestParser(self):
         parser = argparse.ArgumentParser()
         return setup_parser(parser)
     
-    def apply_overlay_all_true(self):
+    def getArgsForApplyOverlayTest(self, overlay_image, overlay_every, overlay_offset, overlay_until):
         parser = self.setupTestParser()
-        args = ['--overlay_image', 'asdf', '--overlay_every', 1, '--overlay_offset', 1, '--overlay_until', 100]
-        result = parser.parse_args(args)
-        self.assertEqual(apply_overlay(args, 10))
+        args = ['--overlay_image', overlay_image, '--overlay_every', str(overlay_every), '--overlay_offset', str(overlay_offset), '--overlay_until', str(overlay_until)]
+        return parser.parse_args(args)
+
+    def test_apply_overlay_all_true(self):
+        args = self.getArgsForApplyOverlayTest('image.png', 1, 0, 100)
+        self.assertEqual(apply_overlay(args, 10), True)
+
+    def test_apply_overlay_no_overlay_image(self):
+        args = self.getArgsForApplyOverlayTest(None, 1, 0, 100)
+        args.overlay_image = None
+        self.assertEqual(apply_overlay(args, 10), False)
+
+    def test_apply_overlay_not_at_offset(self):
+        args = self.getArgsForApplyOverlayTest('image.png', 5, 10, 100)
+        self.assertEqual(apply_overlay(args, 10), False)
+
+    def test_apply_overlay_less_than_overlay_until(self):
+        args = self.getArgsForApplyOverlayTest('image.png', 1, 0, 5)
+        self.assertEqual(apply_overlay(args, 10), False)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**Summary of changes:**

- Added `--overlay_until` option.
  - Takes an integer argument that is the number of iterations.
  - Default value is `None`.


Tests can be run by executing `python -m unittest tests/test_pixray.py` from the main pixray directory.