### PR TITLE
Add docs for settings on Replicate

### DIFF
--- a/cogrun.py
+++ b/cogrun.py
@@ -123,7 +123,7 @@ class Tiler(BasePixrayPredictor):
 
 class PixrayVdiff(BasePixrayPredictor):
     @cog.input("prompts", type=str, help="text prompt", default="Manhattan skyline at sunset. #artstation 🌇")
-    @cog.input("settings", type=str, help="extra settings", default='\n')
+    @cog.input("settings", type=str, help="extra settings in `name: value` format. reference: https://dazhizhong.gitbook.io/pixray-docs/docs/primary-settings", default='\n')
     def predict(self, prompts, settings):
         ydict = yaml.safe_load(settings)
         if ydict == None:


### PR DESCRIPTION
The only way to figure out what the settings are is to look at the examples.

I don't think we actually support markdown or clickable URLs in help
text yet, but this is good motivation to add that support. :D