### PR TITLE
Make apt-get update/install single line

### DIFF
--- a/cog.yaml
+++ b/cog.yaml
@@ -4,9 +4,8 @@ build:
   python_version: "3.8"
   python_requirements: "requirements.txt"
   run:
+    - "apt-get update && apt install -y libgl1-mesa-glx"
     # CMAKE_PREFIX_PATH fix is from https://github.com/readthedocs/readthedocs.org/issues/5867
-    - "apt-get update"
-    - "apt install -y libgl1-mesa-glx"
     - "git clone https://github.com/pixray/diffvg && cd diffvg && git submodule update --init --recursive && CMAKE_PREFIX_PATH=$(pyenv prefix) DIFFVG_CUDA=1 python setup.py install"
 # predict: "cogrun.py:Text2Image"
 # predict: "cogrun.py:Text2Pixel"


### PR DESCRIPTION
This is a little Docker gotchya -- at some point the apt repositories
will change, then apt-get install will fail because it's using the old
cached output of update.

We should make it harder to trip up on this in Cog, or document it, or
something...