### PR TITLE
update predictors to use Cog's new Pydantic API

### DIFF
--- a/cogrun.py
+++ b/cogrun.py
@@ -1,5 +1,4 @@
-from cog import BasePredictor, Input
-from pathlib import Path
+from cog import BasePredictor, Input, Path
 from typing import Iterator
 import torch
 import yaml
@@ -24,7 +23,7 @@ class BasePixrayPredictor(BasePredictor):
     def predict(self, 
         settings: str = Input(description="Default settings to use"),
         prompts: str = Input(description="Text prompts", default=None),
-    **kwargs) -> Iterator[str]:
+    **kwargs) -> Iterator[Path]:
         # workaround for import issue when deploying
         import pixray
         """Run a single prediction on the model"""
@@ -59,7 +58,7 @@ class PixrayVqgan(BasePixrayPredictor):
         # num_cuts: int = Input(description="number of cuts", default=24, ge:4, le:96),
         # batches: int = Input(description="number of batches", default=1, ge:1, le:32),
         **kwargs
-    ) -> Iterator[str]:
+    ) -> Iterator[Path]:
         yield from super().predict(settings="pixray_vqgan", **kwargs)
 
 class PixrayPixel(BasePixrayPredictor):
@@ -68,7 +67,7 @@ class PixrayPixel(BasePixrayPredictor):
         aspect: str = Input(description="wide vs square", default="widescreen", choices=["widescreen", "square"]),
         drawer: str = Input(description="render enging", default="pixel", choices=["pixel", "vqgan", "line_sketch", "clipdraw"]),
         **kwargs
-    ) -> Iterator[str]:
+    ) -> Iterator[Path]:
         yield from super().predict(settings="pixray_pixel", **kwargs)
 
 class Text2Image(BasePixrayPredictor):
@@ -77,7 +76,7 @@ class Text2Image(BasePixrayPredictor):
         quality: str = Input(description="speed vs quality", default="normal", choices=["draft", "normal", "better", "best"]),
         aspect: str = Input(description="wide or narrow", default="widescreen", choices=["widescreen", "square", "portrait"]),
         **kwargs
-    ) -> Iterator[str]:
+    ) -> Iterator[Path]:
         yield from super().predict(settings="text2image", **kwargs)
 
 class Text2Pixel(BasePixrayPredictor):
@@ -86,14 +85,14 @@ class Text2Pixel(BasePixrayPredictor):
         aspect: str = Input(description="wide or narrow", default="widescreen", choices=["widescreen", "square", "portrait"]),
         pixel_scale: float = Input(description="bigger pixels", default=1.0, ge=0.5, le=2.0),
         **kwargs
-    ) -> Iterator[str]:
+    ) -> Iterator[Path]:
         yield from super().predict(settings="text2pixel", **kwargs)
 
 class PixrayRaw(BasePixrayPredictor):
     def predict(self, 
         prompts: str = Input(description="text prompt", default="Manhattan skyline at sunset. #pixelart"),
         settings: str = Input(description="yaml settings", default="\n")
-    ) -> Iterator[str]:
+    ) -> Iterator[Path]:
         ydict = yaml.safe_load(settings)
         if ydict == None:
             # no settings
@@ -103,7 +102,7 @@ class PixrayRaw(BasePixrayPredictor):
 class PixrayApi(BasePixrayPredictor):
     def predict(self, 
         settings: str = Input(description="yaml settings", default="\n")
-    ) -> Iterator[str]:
+    ) -> Iterator[Path]:
         ydict = yaml.safe_load(settings)
         if ydict == None:
             # no settings
@@ -116,7 +115,7 @@ class Tiler(BasePixrayPredictor):
         pixelart: bool = Input(description="pixelart style?", default=False),
         mirror: bool = Input(description="shifted pattern?", default=False),
         settings: str = Input(description="yaml settings", default="\n")
-    ) -> Iterator[str]:
+    ) -> Iterator[Path]:
         ydict = yaml.safe_load(settings)
         if ydict == None:
             # no settings
@@ -138,7 +137,7 @@ class PixrayVdiff(BasePixrayPredictor):
     def predict(self, 
         prompts: str = Input(description="text prompt", default="Manhattan skyline at sunset. #artstation 🌇"),
         settings: str = Input(description="extra settings in `name: value` format. reference: https://dazhizhong.gitbook.io/pixray-docs/docs/primary-settings", default='\n')
-    ) -> Iterator[str]:
+    ) -> Iterator[Path]:
         ydict = yaml.safe_load(settings)
         if ydict == None:
             # no settings

--- a/cogrun.py
+++ b/cogrun.py
@@ -48,7 +48,7 @@ class BasePixrayPredictor(BasePredictor):
             run_complete = pixray.do_run(settings, return_display=True)
             output_file = os.path.join(settings.outdir, settings.output)
             temp_copy = create_temporary_copy(output_file)
-            yield pathlib.Path(os.path.realpath(temp_copy))
+            yield Path(os.path.realpath(temp_copy))
 
 class PixrayVqgan(BasePixrayPredictor):
     def predict(self, 

--- a/cogrun.py
+++ b/cogrun.py
@@ -1,5 +1,6 @@
-import cog
+from cog import BasePredictor, Input
 from pathlib import Path
+from typing import Iterator
 import torch
 import yaml
 import pathlib
@@ -15,15 +16,15 @@ def create_temporary_copy(src_path):
     shutil.copy2(src_path, temp_path)
     return temp_path
 
-class BasePixrayPredictor(cog.Predictor):
+class BasePixrayPredictor(BasePredictor):
     def setup(self):
         print("---> BasePixrayPredictor Setup")
         os.environ['TORCH_HOME'] = 'models/'
 
-    # Define the input types for a prediction
-    @cog.input("settings", type=str, help="Default settings to use")
-    @cog.input("prompts", type=str, help="Text Prompts")
-    def predict(self, settings, **kwargs):
+    def predict(self, 
+        settings: str = Input(description="Default settings to use"),
+        prompts: str = Input(description="Text prompts", default=None),
+    **kwargs) -> Iterator[str]:
         # workaround for import issue when deploying
         import pixray
         """Run a single prediction on the model"""
@@ -51,39 +52,48 @@ class BasePixrayPredictor(cog.Predictor):
             yield pathlib.Path(os.path.realpath(temp_copy))
 
 class PixrayVqgan(BasePixrayPredictor):
-    @cog.input("prompts", type=str, help="text prompt", default="rainbow mountain")
-    @cog.input("quality", type=str, help="better is slower", default="normal", options=["draft", "normal", "better", "best"])
-    @cog.input("aspect", type=str, help="wide vs square", default="widescreen", options=["widescreen", "square"])
-    # @cog.input("num_cuts", type=int, default="24", min=4, max=96)
-    # @cog.input("batches", type=int, default="1", min=1, max=32)
-    def predict(self, **kwargs):
+    def predict(self, 
+        prompts: str = Input(description="text prompt", default="rainbow mountain"),
+        quality: str = Input(description="better is slower", default="normal", choices=["draft", "normal", "better", "best"]),
+        aspect: str = Input(description="wide vs square", default="widescreen", choices=["widescreen", "square"]),
+        # num_cuts: int = Input(description="number of cuts", default=24, ge:4, le:96),
+        # batches: int = Input(description="number of batches", default=1, ge:1, le:32),
+        **kwargs
+    ) -> Iterator[str]:
         yield from super().predict(settings="pixray_vqgan", **kwargs)
 
 class PixrayPixel(BasePixrayPredictor):
-    @cog.input("prompts", type=str, help="text prompt", default="Beirut Skyline. #pixelart")
-    @cog.input("aspect", type=str, help="wide vs square", default="widescreen", options=["widescreen", "square"])
-    @cog.input("drawer", type=str, help="render engine", default="pixel", options=["pixel", "vqgan", "line_sketch", "clipdraw"])
-    def predict(self, **kwargs):
+    def predict(self, 
+        prompts: str = Input(description="text promps", default="Beirut Skyline. #pixelart"),
+        aspect: str = Input(description="wide vs square", default="widescreen", choices=["widescreen", "square"]),
+        drawer: str = Input(description="render enging", default="pixel", choices=["pixel", "vqgan", "line_sketch", "clipdraw"]),
+        **kwargs
+    ) -> Iterator[str]:
         yield from super().predict(settings="pixray_pixel", **kwargs)
 
 class Text2Image(BasePixrayPredictor):
-    @cog.input("prompts", type=str, help="description of what to draw", default="Robots skydiving high above the city")
-    @cog.input("quality", type=str, help="speed vs quality", default="normal", options=["draft", "normal", "better", "best"])
-    @cog.input("aspect", type=str, help="wide or narrow", default="widescreen", options=["widescreen", "square", "portrait"])
-    def predict(self, **kwargs):
+    def predict(self, 
+        prompts: str = Input(description="description of what to draw", default="Robots skydiving high above the city"),
+        quality: str = Input(description="speed vs quality", default="normal", choices=["draft", "normal", "better", "best"]),
+        aspect: str = Input(description="wide or narrow", default="widescreen", choices=["widescreen", "square", "portrait"]),
+        **kwargs
+    ) -> Iterator[str]:
         yield from super().predict(settings="text2image", **kwargs)
 
 class Text2Pixel(BasePixrayPredictor):
-    @cog.input("prompts", type=str, help="text prompt", default="Manhattan skyline at sunset. #pixelart")
-    @cog.input("aspect", type=str, help="wide or narrow", default="widescreen", options=["widescreen", "square", "portrait"])
-    @cog.input("pixel_scale", type=float, help="bigger pixels", default=1.0, min=0.5, max=2.0)
-    def predict(self, **kwargs):
+    def predict(self, 
+        prompts: str = Input(description="text prompt", default="Manhattan skyline at sunset. #pixelart"),
+        aspect: str = Input(description="wide or narrow", default="widescreen", choices=["widescreen", "square", "portrait"]),
+        pixel_scale: float = Input(description="bigger pixels", default=1.0, ge=0.5, le=2.0),
+        **kwargs
+    ) -> Iterator[str]:
         yield from super().predict(settings="text2pixel", **kwargs)
 
 class PixrayRaw(BasePixrayPredictor):
-    @cog.input("prompts", type=str, help="text prompt", default="Manhattan skyline at sunset. #pixelart")
-    @cog.input("settings", type=str, help="yaml settings", default='\n')
-    def predict(self, prompts, settings):
+    def predict(self, 
+        prompts: str = Input(description="text prompt", default="Manhattan skyline at sunset. #pixelart"),
+        settings: str = Input(description="yaml settings", default="\n")
+    ) -> Iterator[str]:
         ydict = yaml.safe_load(settings)
         if ydict == None:
             # no settings
@@ -91,8 +101,9 @@ class PixrayRaw(BasePixrayPredictor):
         yield from super().predict(settings="pixrayraw", prompts=prompts, **ydict)
 
 class PixrayApi(BasePixrayPredictor):
-    @cog.input("settings", type=str, help="yaml settings", default='\n')
-    def predict(self, settings):
+    def predict(self, 
+        settings: str = Input(description="yaml settings", default="\n")
+    ) -> Iterator[str]:
         ydict = yaml.safe_load(settings)
         if ydict == None:
             # no settings
@@ -100,11 +111,12 @@ class PixrayApi(BasePixrayPredictor):
         yield from super().predict(settings="pixrayapi", **ydict)
 
 class Tiler(BasePixrayPredictor):
-    @cog.input("prompts", type=str, help="text prompt", default="Beautiful marble texture")
-    @cog.input("pixelart", type=bool, help="pixelart style?", default=False)
-    @cog.input("mirror", type=bool, help="shifted pattern?", default=False)
-    @cog.input("settings", type=str, help="yaml settings", default='\n')
-    def predict(self, prompts, pixelart, mirror, settings):
+    def predict(self, 
+        prompts: str = Input(description="text prompt", default=""),
+        pixelart: bool = Input(description="pixelart style?", default=False),
+        mirror: bool = Input(description="shifted pattern?", default=False),
+        settings: str = Input(description="yaml settings", default="\n")
+    ) -> Iterator[str]:
         ydict = yaml.safe_load(settings)
         if ydict == None:
             # no settings
@@ -123,12 +135,12 @@ class Tiler(BasePixrayPredictor):
             yield from super().predict(prompts=prompts, settings=settings, **ydict)    
 
 class PixrayVdiff(BasePixrayPredictor):
-    @cog.input("prompts", type=str, help="text prompt", default="Manhattan skyline at sunset. #artstation 🌇")
-    @cog.input("settings", type=str, help="extra settings in `name: value` format. reference: https://dazhizhong.gitbook.io/pixray-docs/docs/primary-settings", default='\n')
-    def predict(self, prompts, settings):
+    def predict(self, 
+        prompts: str = Input(description="text prompt", default="Manhattan skyline at sunset. #artstation 🌇"),
+        settings: str = Input(description="extra settings in `name: value` format. reference: https://dazhizhong.gitbook.io/pixray-docs/docs/primary-settings", default='\n')
+    ) -> Iterator[str]:
         ydict = yaml.safe_load(settings)
         if ydict == None:
             # no settings
             ydict = {}
         yield from super().predict(settings="pixray_vdiff", prompts=prompts, **ydict)
-


### PR DESCRIPTION
Hey @dribnet 👋🏼 

This PR updates pixray's Cog predictor classes to be compatible with [Cog's new Python API](https://github.com/replicate/cog/blob/703db05575a044da887aff2f1858e20be9d225df/docs/python.md).

Cog v0.1.0 has a new predictor API that makes use of Python's built-in type annotations to declare input and output types. The new API also has a different way of declaring inputs based on [pydantic](https://pydantic-docs.helpmanual.io/), a python package for validating Python models. Instead of using the `@cog.input` decorators, inputs are now declared inline as parameters to the `predict()` method.

There's a bunch of other useful foundational stuff in this new release of Cog that gets us closer to having a standardize type system that leans on JSON Schema and OpenAPI instead of re-inventing our own thing. For more details, see the release notes here: https://github.com/replicate/cog/releases/tag/v0.1.0

### Process

Here's the process I followed to set things up, make changes, and test:

1. created a new model https://replicate.com/zeke/pydantic-pixray
1. forked this repo, recursively cloned it, and `cog push`ed it to zeke/pydantic-pixray using "old cog" (0.0.x)
1. verified that my unchanged fork of pixray worked by running some predictions
1. upgraded my local Cog version to the latest, [`0.1.1`](https://github.com/replicate/cog/releases/tag/v0.1.1)
1. updated all the Predictors in `cogrun.py` to use `cog.BasePredictor`, `cog.Input`, `cog.Path` etc.
1. set the `image` field in cog.yaml to publish to my own copy of the model and the `predict` field to `cogrun.py:PixrayVdiff`
1. published using `cog push`
1. ran `cog predict` from a GCP image with a GPU. See https://gist.github.com/zeke/a36c059bebb751fb21b26c1d14ed1996

### Progress

I am now able to `cog build`, `cog push`, and `cog predict` the changes herein using the latest version of Cog, but still hitting a few snags:

- The `PixrayVdiff` predictor (which I think corresponds to https://replicate.com/pixray/text2image) produces output, but it's yielding the same image over and over. See https://gist.github.com/zeke/a36c059bebb751fb21b26c1d14ed1996
- Some of the existing predictors accept a `kwargs` argument, but the new version of Cog has a strict list of [allowed input types](https://github.com/replicate/cog/blob/6c6988d1ff65aef3a9fdb96f167a86972508190f/python/cog/predictor.py#L20:L20). In order to be compatible with Cog's new type checking stuff, these predictors that accept arbitrary keyword arguments will need to be expanded to explicitly list all the arguments and their types.

### Next steps

@dribnet hopefully this gives you a head start for updating pixray to work with the new version of Cog. Let me know if this all makes sense, and if you need more help getting these changes shipped.