### PR TITLE
associate Cog predictors with Replicate images

### DIFF
--- a/cog.yaml
+++ b/cog.yaml
@@ -7,13 +7,25 @@ build:
     - "apt-get update && apt install -y libgl1-mesa-glx"
     # CMAKE_PREFIX_PATH fix is from https://github.com/readthedocs/readthedocs.org/issues/5867
     - "git clone https://github.com/pixray/diffvg && cd diffvg && git submodule update --init --recursive && CMAKE_PREFIX_PATH=$(pyenv prefix) DIFFVG_CUDA=1 python setup.py install && pip install basicsr"
-# predict: "cogrun.py:Text2Image"
-# predict: "cogrun.py:Text2Pixel"
-# predict: "cog_genesis.py:GenesisPredictor"
+
+# image: "r8.im/pixray/api"
 # predict: "cogrun.py:PixrayApi"
+
+# image: "r8.im/pixray/text2image"
+# predict: "cogrun.py:Text2Image"
+
+# image: "r8.im/dribnet/pixray-text2pixel"
+# predict: "cogrun.py:Text2Pixel"
+
+# image: "r8.im/dribnet/pixray-genesis"
+# predict: "cog_genesis.py:GenesisPredictor"
+
+# image: "r8.im/dribnet/pixray-tiler"
 # predict: "cogrun.py:Tiler"
+
 # predict: "cogrun.py:PixrayRaw"
-predict: "cogrun.py:PixrayVdiff"
+# predict: "cogrun.py:PixrayVdiff"
+
 # OLDSTUFF
 # predict: "cogrun.py:BasePixrayPredictor"
 # predict: "cogrun.py:PixrayVqgan"


### PR DESCRIPTION
Hey @dribnet 👋🏼 

This PR is an attempt to map the various Cog predictors in `cog.yaml` to their published images in the Replicate registry. The aim of this is to simplify the `cog push` process for you the author, and leave behind some documentation so code spelunkers can more easily find the published model associated with each predictor.

I'm guessing your current workflow is to uncomment a line in cog.yaml and then `cog push r8.im/some/model`. With this proposed change in place, you'd instead uncomment the `image`/`predict` pair, save the file, and run `cog push` with no arguments.

I attempted to map these as best I could, but there are a handful of models on Replicate that aren't represented here in cog.yaml, and vice-versa. If you think this idea is worth pursuing, we can finish getting those mappings right.
